### PR TITLE
Mover los DTOs a un proyecto separado

### DIFF
--- a/DSS_Scoring.Client/DSS_Scoring.Client.csproj
+++ b/DSS_Scoring.Client/DSS_Scoring.Client.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DSS_Scoring.Shared\DSS_Scoring.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/DSS_Scoring.Shared/DSS_Scoring.Shared.csproj
+++ b/DSS_Scoring.Shared/DSS_Scoring.Shared.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/DSS_Scoring.Shared/DTOs/AlternativaDTO.cs
+++ b/DSS_Scoring.Shared/DTOs/AlternativaDTO.cs
@@ -1,4 +1,5 @@
-﻿namespace DSS_Scoring.DTOs
+﻿namespace DSS_Scoring.Shared.DTOs
+
 {
     public class AlternativaDTO
     {

--- a/DSS_Scoring.Shared/DTOs/CriterioDTO.cs
+++ b/DSS_Scoring.Shared/DTOs/CriterioDTO.cs
@@ -1,4 +1,5 @@
-﻿namespace DSS_Scoring.DTOs
+﻿namespace DSS_Scoring.Shared.DTOs
+
 {
     public class CriterioDTO
     {

--- a/DSS_Scoring.Shared/DTOs/MatrizDTO.cs
+++ b/DSS_Scoring.Shared/DTOs/MatrizDTO.cs
@@ -1,6 +1,5 @@
-﻿using DSS_Scoring.Models;
+﻿namespace DSS_Scoring.Shared.DTOs
 
-namespace DSS_Scoring.DTOs
 {
     public class MatrizDTO
     {

--- a/DSS_Scoring.Shared/DTOs/ProyectoDTO.cs
+++ b/DSS_Scoring.Shared/DTOs/ProyectoDTO.cs
@@ -1,6 +1,5 @@
-﻿using DSS_Scoring.Models;
+﻿namespace DSS_Scoring.Shared.DTOs
 
-namespace DSS_Scoring.DTOs
 {
     public class ProyectoDTO
     {

--- a/DSS_Scoring.Shared/DTOs/ResultadoDTO.cs
+++ b/DSS_Scoring.Shared/DTOs/ResultadoDTO.cs
@@ -1,6 +1,5 @@
-﻿using DSS_Scoring.Models;
+﻿namespace DSS_Scoring.Shared.DTOs
 
-namespace DSS_Scoring.DTOs
 {
     public class ResultadoDTO
     {

--- a/DSS_Scoring/Controllers/AlternativasController.cs
+++ b/DSS_Scoring/Controllers/AlternativasController.cs
@@ -1,6 +1,6 @@
 ﻿using DSS_Scoring.Data;
-using DSS_Scoring.DTOs;
 using DSS_Scoring.Models;
+using DSS_Scoring.Shared.DTOs;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -58,7 +58,7 @@ namespace DSS_Scoring.Controllers
                 return NotFound();
             }
 
-            var alternativasPorProyecto = await _context.Alternativas.Where(a=> a.IdProyecto == idProyecto).ToListAsync();
+            var alternativasPorProyecto = await _context.Alternativas.Where(a => a.IdProyecto == idProyecto).ToListAsync();
 
             var results = alternativasPorProyecto.Adapt<List<AlternativaDTO>>();
 

--- a/DSS_Scoring/Controllers/CriteriosController.cs
+++ b/DSS_Scoring/Controllers/CriteriosController.cs
@@ -1,7 +1,6 @@
-﻿using DSS_Scoring.Client.Pages;
-using DSS_Scoring.Data;
-using DSS_Scoring.DTOs;
+﻿using DSS_Scoring.Data;
 using DSS_Scoring.Models;
+using DSS_Scoring.Shared.DTOs;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/DSS_Scoring/Controllers/MatricesController.cs
+++ b/DSS_Scoring/Controllers/MatricesController.cs
@@ -1,6 +1,6 @@
 ﻿using DSS_Scoring.Data;
-using DSS_Scoring.DTOs;
 using DSS_Scoring.Models;
+using DSS_Scoring.Shared.DTOs;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -111,7 +111,7 @@ namespace DSS_Scoring.Controllers
                 }
 
                 // Se agregará un elemento por cada alternativa registrada en el proyecto
-                resultados.Add(alternativaDTO);                
+                resultados.Add(alternativaDTO);
             }
 
             return Ok(resultados);

--- a/DSS_Scoring/Controllers/ProyectosController.cs
+++ b/DSS_Scoring/Controllers/ProyectosController.cs
@@ -1,6 +1,6 @@
 ﻿using DSS_Scoring.Data;
-using DSS_Scoring.DTOs;
 using DSS_Scoring.Models;
+using DSS_Scoring.Shared.DTOs;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/DSS_Scoring/Controllers/ResultadosController.cs
+++ b/DSS_Scoring/Controllers/ResultadosController.cs
@@ -1,6 +1,6 @@
 ﻿using DSS_Scoring.Data;
-using DSS_Scoring.DTOs;
 using DSS_Scoring.Models;
+using DSS_Scoring.Shared.DTOs;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -23,7 +23,7 @@ namespace DSS_Scoring.Controllers
         public async Task<ActionResult<IEnumerable<ResultadoDTO>>> GetAll()
         {
             var res = await _context.Resultados.ToListAsync();
-            
+
             var resultados = res.Adapt<List<ResultadoDTO>>();
 
             return Ok(resultados);

--- a/DSS_Scoring/DSS_Scoring.csproj
+++ b/DSS_Scoring/DSS_Scoring.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DSS_Scoring.Client\DSS_Scoring.Client.csproj" />
     <PackageReference Include="Blazor.Bootstrap" Version="3.0.0" />
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.8" />
@@ -33,6 +32,11 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.8.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DSS_Scoring.Client\DSS_Scoring.Client.csproj" />
+    <ProjectReference Include="..\DSS_Scoring.Shared\DSS_Scoring.Shared.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 Se movieron los DTOs a un proyecto separado para poder usar las clases en ambos proyectos. Se hizo la conexion del proyecto frontend (DSS_Scoring.Client) y el del backend (DSS_Scoring) con ese proyecto (DSS_Scoring.Shared). 